### PR TITLE
updated hmat.r to deal with empty list of facets

### DIFF
--- a/R/hmat.r
+++ b/R/hmat.r
@@ -49,6 +49,14 @@ hmat <- function(varlvls, facets){
   nCells   <- length(colNames)
   
   
+  # if empty list of facets
+  if (length(facets) == 0) {
+    rowName = strrep("+", length(varlvls))
+    A <- matrix(rep(1L, prod(varlvls)), nrow = 1, dimnames = list(rowName, colNames))
+    return(A)
+  }
+  
+  
   # make rownames
   configsPerFacet <- vapply(facets, function(facet) prod(varlvls[facet]), numeric(1))
   totalRows       <- sum(configsPerFacet)


### PR DESCRIPTION
The hmat function used to throw an error when the facets argument was an empty list (which would be useful, for example, when you want to sample from the space of all possible contingency tables on a given number of observations). I added a few lines of code to deal with this special case. Now, when the facets argument is an empty list, hmat returns a matrix consisting of a single row of 1's. This code is only invoked when length(facets) == 0, so it hopefully won't cause any breakage elsewhere. 